### PR TITLE
feat: implement Client entity, service, controller and create endpoint

### DIFF
--- a/src/main/java/com/smartinvoice/client/controller/ClientController.java
+++ b/src/main/java/com/smartinvoice/client/controller/ClientController.java
@@ -1,0 +1,23 @@
+package com.smartinvoice.client.controller;
+
+import com.smartinvoice.client.dto.ClientRequestDto;
+import com.smartinvoice.client.dto.ClientResponseDto;
+import com.smartinvoice.client.service.ClientService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/clients")
+@RequiredArgsConstructor
+public class ClientController {
+
+    private final ClientService clientService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ClientResponseDto create(@Valid @RequestBody ClientRequestDto dto) {
+        return clientService.createClient(dto);
+    }
+}

--- a/src/main/java/com/smartinvoice/client/dto/ClientRequestDto.java
+++ b/src/main/java/com/smartinvoice/client/dto/ClientRequestDto.java
@@ -1,0 +1,11 @@
+package com.smartinvoice.client.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ClientRequestDto(
+        @NotBlank String name,
+        @NotBlank @Email String email,
+        String companyName,
+        String address
+) {}

--- a/src/main/java/com/smartinvoice/client/dto/ClientResponseDto.java
+++ b/src/main/java/com/smartinvoice/client/dto/ClientResponseDto.java
@@ -1,0 +1,9 @@
+package com.smartinvoice.client.dto;
+
+public record ClientResponseDto(
+        Long id,
+        String name,
+        String email,
+        String companyName,
+        String address
+) {}

--- a/src/main/java/com/smartinvoice/client/entity/Client.java
+++ b/src/main/java/com/smartinvoice/client/entity/Client.java
@@ -1,0 +1,23 @@
+package com.smartinvoice.client.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "clients")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Client {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String email;
+    private String companyName;
+    private String address;
+}

--- a/src/main/java/com/smartinvoice/client/repository/ClientRepository.java
+++ b/src/main/java/com/smartinvoice/client/repository/ClientRepository.java
@@ -1,0 +1,7 @@
+package com.smartinvoice.client.repository;
+
+import com.smartinvoice.client.entity.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClientRepository extends JpaRepository<Client, Long> {
+}

--- a/src/main/java/com/smartinvoice/client/service/ClientService.java
+++ b/src/main/java/com/smartinvoice/client/service/ClientService.java
@@ -1,0 +1,34 @@
+package com.smartinvoice.client.service;
+
+import com.smartinvoice.client.dto.ClientRequestDto;
+import com.smartinvoice.client.dto.ClientResponseDto;
+import com.smartinvoice.client.entity.Client;
+import com.smartinvoice.client.repository.ClientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ClientService {
+
+    private final ClientRepository repository;
+
+    public ClientResponseDto createClient(ClientRequestDto dto) {
+        Client client = Client.builder()
+                .name(dto.name())
+                .email(dto.email())
+                .companyName(dto.companyName())
+                .address(dto.address())
+                .build();
+
+        Client saved = repository.save(client);
+
+        return new ClientResponseDto(
+                saved.getId(),
+                saved.getName(),
+                saved.getEmail(),
+                saved.getCompanyName(),
+                saved.getAddress()
+        );
+    }
+}


### PR DESCRIPTION
Introduces the fundamental building blocks for client management:
- Defines the Client entity.
- Creates ClientRequest and ClientResponse DTOs for data transfer.
- Establishes the ClientRepository interface for data access.
- Implements the ClientService with a `createClient` method for business logic.
- Adds the ClientController with a `create` endpoint for API interaction.