### PR TITLE
Disable Spring Security temporarily for development testing

### DIFF
--- a/src/main/java/com/smartinvoice/config/SecurityConfig.java
+++ b/src/main/java/com/smartinvoice/config/SecurityConfig.java
@@ -1,0 +1,20 @@
+package com.smartinvoice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+}


### PR DESCRIPTION
Created SecurityConfig to disable temporary Spring Security for API testing purpose.