### PR TITLE
Handle client not found with 404 error response

### DIFF
--- a/src/main/java/com/smartinvoice/client/service/ClientService.java
+++ b/src/main/java/com/smartinvoice/client/service/ClientService.java
@@ -4,6 +4,7 @@ import com.smartinvoice.client.dto.ClientRequestDto;
 import com.smartinvoice.client.dto.ClientResponseDto;
 import com.smartinvoice.client.entity.Client;
 import com.smartinvoice.client.repository.ClientRepository;
+import com.smartinvoice.exception.ResourceNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,7 +53,7 @@ public class ClientService {
     // Get a client by ID
     public ClientResponseDto getClientById(Long id) {
         Client client = repository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Client not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Client not found"));
 
         return new ClientResponseDto(
                 client.getId(),
@@ -66,7 +67,7 @@ public class ClientService {
     // Update a client
     public ClientResponseDto updateClient(Long id, ClientRequestDto dto) {
         Client existingClient = repository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Client not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Client not found"));
 
         existingClient.setName(dto.name());
         existingClient.setEmail(dto.email());
@@ -87,7 +88,7 @@ public class ClientService {
     // Delete a client
     public void deleteClient(Long id) {
         Client existingClient = repository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Client not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Client not found"));
 
         repository.delete(existingClient);
     }

--- a/src/main/java/com/smartinvoice/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/smartinvoice/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.smartinvoice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Replaced generic `EntityNotFoundException` with a custom `ResourceNotFoundException` to provide clearer, REST-friendly error handling.

Added the `@ResponseStatus(HttpStatus.NOT_FOUND)` annotation to ensure Spring returns a 404 Not Found when a client is not found.

Updated the `ClientService` methods (`getClientById`, `updateClient`, `deleteClient`) to throw `ResourceNotFoundException` instead of `EntityNotFoundException`.

This improves API clarity and avoids returning <ins>HTTP 500</ins> on missing resources.