### PR TITLE
refactor: move Product module from client package to product package

### DIFF
--- a/src/main/java/com/smartinvoice/product/controller/ProductController.java
+++ b/src/main/java/com/smartinvoice/product/controller/ProductController.java
@@ -1,8 +1,8 @@
-package com.smartinvoice.client.controller;
+package com.smartinvoice.product.controller;
 
-import com.smartinvoice.client.dto.ProductRequestDto;
-import com.smartinvoice.client.dto.ProductResponseDto;
-import com.smartinvoice.client.service.ProductService;
+import com.smartinvoice.product.dto.ProductRequestDto;
+import com.smartinvoice.product.dto.ProductResponseDto;
+import com.smartinvoice.product.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/smartinvoice/product/dto/ProductRequestDto.java
+++ b/src/main/java/com/smartinvoice/product/dto/ProductRequestDto.java
@@ -1,4 +1,4 @@
-package com.smartinvoice.client.dto;
+package com.smartinvoice.product.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/smartinvoice/product/dto/ProductResponseDto.java
+++ b/src/main/java/com/smartinvoice/product/dto/ProductResponseDto.java
@@ -1,4 +1,4 @@
-package com.smartinvoice.client.dto;
+package com.smartinvoice.product.dto;
 
 public record ProductResponseDto(
         Long id,

--- a/src/main/java/com/smartinvoice/product/entity/Product.java
+++ b/src/main/java/com/smartinvoice/product/entity/Product.java
@@ -1,4 +1,4 @@
-package com.smartinvoice.client.entity;
+package com.smartinvoice.product.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/smartinvoice/product/repository/ProductRepository.java
+++ b/src/main/java/com/smartinvoice/product/repository/ProductRepository.java
@@ -1,6 +1,6 @@
-package com.smartinvoice.client.repository;
+package com.smartinvoice.product.repository;
 
-import com.smartinvoice.client.entity.Product;
+import com.smartinvoice.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {

--- a/src/main/java/com/smartinvoice/product/service/ProductService.java
+++ b/src/main/java/com/smartinvoice/product/service/ProductService.java
@@ -1,9 +1,9 @@
-package com.smartinvoice.client.service;
+package com.smartinvoice.product.service;
 
-import com.smartinvoice.client.dto.ProductRequestDto;
-import com.smartinvoice.client.dto.ProductResponseDto;
-import com.smartinvoice.client.entity.Product;
-import com.smartinvoice.client.repository.ProductRepository;
+import com.smartinvoice.product.dto.ProductRequestDto;
+import com.smartinvoice.product.dto.ProductResponseDto;
+import com.smartinvoice.product.entity.Product;
+import com.smartinvoice.product.repository.ProductRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
* Created new package tree `com.smartinvoice.product.*`
* Moved Product entity, DTOs, repository, service, controller and tests from the mistaken client package to the correct product package
* Updated all package declarations and imports
* Verified build and tests pass

This isolates the Product module cleanly and prevents naming collisions with the Client module.
