### PR TITLE
feat: create initial Invoice module with entity, DTOs and repository

### DIFF
--- a/src/main/java/com/smartinvoice/invoice/dto/InvoiceRequestDto.java
+++ b/src/main/java/com/smartinvoice/invoice/dto/InvoiceRequestDto.java
@@ -1,0 +1,12 @@
+package com.smartinvoice.invoice.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record InvoiceRequestDto(
+        String invoiceNumber,
+        LocalDate issueDate,
+        LocalDate dueDate,
+        Long clientId,
+        List<Long> productIds
+) {}

--- a/src/main/java/com/smartinvoice/invoice/dto/InvoiceResponseDto.java
+++ b/src/main/java/com/smartinvoice/invoice/dto/InvoiceResponseDto.java
@@ -1,0 +1,14 @@
+package com.smartinvoice.invoice.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record InvoiceResponseDto(
+        Long id,
+        String invoiceNumber,
+        LocalDate issueDate,
+        LocalDate dueDate,
+        double totalAmount,
+        Long clientId,
+        List<Long> productIds
+) {}

--- a/src/main/java/com/smartinvoice/invoice/entity/Invoice.java
+++ b/src/main/java/com/smartinvoice/invoice/entity/Invoice.java
@@ -1,0 +1,43 @@
+package com.smartinvoice.invoice.entity;
+
+import com.smartinvoice.client.entity.Client;
+import com.smartinvoice.product.entity.Product;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Table(name = "invoices")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Invoice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String invoiceNumber;
+
+    private LocalDate issueDate;
+
+    private LocalDate dueDate;
+
+    private double totalAmount;
+
+    @ManyToOne
+    @JoinColumn(name = "client_id")
+    private Client client;
+
+    @ManyToMany
+    @JoinTable(
+            name = "invoice_products",
+            joinColumns = @JoinColumn(name = "invoice_id"),
+            inverseJoinColumns = @JoinColumn(name = "product_id")
+    )
+    private List<Product> products;
+}

--- a/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
+++ b/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
@@ -1,0 +1,7 @@
+package com.smartinvoice.invoice.repository;
+
+import com.smartinvoice.invoice.entity.Invoice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InvoiceRepository extends JpaRepository<Invoice, Long> {
+}


### PR DESCRIPTION
Initial setup for the Invoice module. Added:

- `Invoice` entity with many-to-many relationship to `Product` and many-to-one to `Client`.
- `InvoiceRequestDto` and `InvoiceResponseDto`.
- `InvoiceRepository`.