### PR TITLE
Added global exception handling

### DIFF
--- a/src/main/java/com/smartinvoice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/smartinvoice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.smartinvoice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<String> handleResourceNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+}

--- a/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
+++ b/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
@@ -1,6 +1,7 @@
 package com.smartinvoice.invoice.service;
 
 import com.smartinvoice.client.repository.ClientRepository;
+import com.smartinvoice.exception.ResourceNotFoundException;
 import com.smartinvoice.invoice.dto.InvoiceRequestDto;
 import com.smartinvoice.invoice.dto.InvoiceResponseDto;
 import com.smartinvoice.invoice.entity.Invoice;
@@ -23,7 +24,7 @@ public class InvoiceService {
 
     public InvoiceResponseDto createInvoice(InvoiceRequestDto dto) {
         var client = clientRepository.findById(dto.clientId())
-                .orElseThrow(() -> new EntityNotFoundException("Client not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Client not found"));
 
         var products = productRepository.findAllById(dto.productIds());
 
@@ -53,14 +54,14 @@ public class InvoiceService {
 
     public InvoiceResponseDto getInvoiceById(Long id) {
         Invoice invoice = invoiceRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Invoice not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Invoice not found"));
 
         return mapToDto(invoice);
     }
 
     public void deleteInvoice(Long id) {
         Invoice invoice = invoiceRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Invoice not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Invoice not found"));
 
         invoiceRepository.delete(invoice);
     }


### PR DESCRIPTION
Added global exception handling using `@ControllerAdvice`. 
Now, when a resource like an invoice or client is not found, the API returns a <ins>404</ins> Not Found with a clear error message instead of a <ins>500</ins> error.

Modified `InvoiceService` to use `ResourceNotFoundException` instead of `EntityNotFoundException` in the following methods:
-  `createInvoice`
- `getInvoiceById` 
- `deleteInvoice`