### PR TITLE
Add functionality to email PDF invoice to client's email address

### DIFF
--- a/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
+++ b/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
@@ -50,4 +50,10 @@ public class InvoiceController {
                 .body(pdf);
     }
 
+    @PostMapping("/{id}/email")
+    @ResponseStatus(HttpStatus.OK)
+    public void emailInvoiceToClient(@PathVariable Long id) {
+        invoiceService.emailInvoiceToClient(id);
+    }
+
 }

--- a/src/main/java/com/smartinvoice/invoice/email/EmailService.java
+++ b/src/main/java/com/smartinvoice/invoice/email/EmailService.java
@@ -1,0 +1,34 @@
+package com.smartinvoice.invoice.email;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendInvoiceEmail(String to, String subject, String body, byte[] pdfBytes, String fileName) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(body);
+
+            ByteArrayResource attachment = new ByteArrayResource(pdfBytes);
+            helper.addAttachment(fileName, attachment);
+
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new RuntimeException("Failed to send email", e);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the ability to email invoices directly to clients. It includes:

A new `EmailService` class responsible for sending emails.
An `emailInvoiceToClient` method in `InvoiceService` to generate and send basic invoices via email.
A corresponding `emailInvoiceToClient` endpoint in `InvoiceController` to handle the HTTP request.