### PR TITLE
fix(client): Include address details when creating clients

### DIFF
--- a/src/main/java/com/smartinvoice/client/service/ClientService.java
+++ b/src/main/java/com/smartinvoice/client/service/ClientService.java
@@ -25,6 +25,9 @@ public class ClientService {
                 .email(dto.email())
                 .companyName(dto.companyName())
                 .address(dto.address())
+                .city(dto.city())
+                .country(dto.country())
+                .postcode(dto.postcode())
                 .build();
 
         Client saved = repository.save(client);


### PR DESCRIPTION
Fixes an issue where newly created clients were missing city, country, and postcode information in their PDF documents. This was due to a bug in the `ClientService.createClient` method where these fields were not being retrieved from the DTO and persisted to the Client entity. This commit ensures that these address details are now correctly saved during client creation.