### PR TITLE
Prevent deleting clients with attached invoices

### DIFF
--- a/src/main/java/com/smartinvoice/client/entity/Client.java
+++ b/src/main/java/com/smartinvoice/client/entity/Client.java
@@ -1,7 +1,11 @@
 package com.smartinvoice.client.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.smartinvoice.invoice.entity.Invoice;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.List;
 
 @Entity
 @Table(name = "clients")
@@ -23,5 +27,7 @@ public class Client {
     private String city;
     private String country;
     private String postcode;
-
+    @OneToMany(mappedBy = "client", cascade = CascadeType.ALL)
+    @JsonManagedReference
+    private List<Invoice> invoices;
 }

--- a/src/main/java/com/smartinvoice/client/service/ClientService.java
+++ b/src/main/java/com/smartinvoice/client/service/ClientService.java
@@ -105,6 +105,11 @@ public class ClientService {
         Client existingClient = repository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Client not found"));
 
+        if (!existingClient.getInvoices().isEmpty()) {
+            throw new IllegalStateException("Client has invoices and cannot be deleted.");
+        }
+
+
         repository.delete(existingClient);
     }
 }

--- a/src/main/java/com/smartinvoice/invoice/entity/Invoice.java
+++ b/src/main/java/com/smartinvoice/invoice/entity/Invoice.java
@@ -1,5 +1,6 @@
 package com.smartinvoice.invoice.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.smartinvoice.client.entity.Client;
 import com.smartinvoice.product.entity.Product;
 import jakarta.persistence.*;
@@ -34,6 +35,7 @@ public class Invoice {
 
     @ManyToOne
     @JoinColumn(name = "client_id")
+    @JsonBackReference
     private Client client;
 
     @ManyToMany

--- a/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
+++ b/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
@@ -46,6 +46,8 @@ public class InvoiceService {
                 .isPaid(dto.isPaid())
                 .build();
 
+        client.getInvoices().add(invoice);
+
         Invoice saved = invoiceRepository.save(invoice);
 
         return mapToDto(saved);


### PR DESCRIPTION
Summary
Added a validation step in the `ClientService` to prevent deletion of a client if they have one or more associated invoices. This ensures referential integrity and avoids accidental data loss of important invoice records.

Changes
- Added check in `deleteClient` method of `ClientService` to throw `IllegalStateException` if invoices exist.
- Added clear exception message to inform the user why the deletion failed.

Reasoning
Invoicing systems should preserve financial records. Preventing deletion of clients with invoices maintains auditability and ensures relational consistency in the database.

