### PR TITLE
Implement Payment Reminder Scheduler for Unpaid Invoices

### DIFF
--- a/src/main/java/com/smartinvoice/SmartInvoiceApplication.java
+++ b/src/main/java/com/smartinvoice/SmartInvoiceApplication.java
@@ -2,8 +2,10 @@ package com.smartinvoice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class SmartInvoiceApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
This PR adds a scheduled job that checks for unpaid invoices and sends reminder emails to clients based on invoice due dates.

Reminder Schedule:
- 3 days before due date
- 1, 5, and 10 days after due date (if still unpaid)

Implementation Details:
- Added a `ReminderScheduler` component using `@Scheduled`.
- Integrated with existing `EmailService` to send reminders.
- Query filters unpaid invoices within date ranges.

Notes:
- The scheduler runs daily at every minute for further testing

To do:
- Setup the scheduler to run daily at 9:00 AM.