### PR TITLE
Fixed PDF generation error

### DIFF
--- a/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
+++ b/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
@@ -2,6 +2,11 @@ package com.smartinvoice.invoice.repository;
 
 import com.smartinvoice.invoice.entity.Invoice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface InvoiceRepository extends JpaRepository<Invoice, Long> {
+    @Query("SELECT i FROM Invoice i LEFT JOIN FETCH i.products WHERE i.isPaid = false")
+    List<Invoice> findAllUnpaidWithProducts();
 }

--- a/src/main/java/com/smartinvoice/invoice/scheduler/ReminderScheduler.java
+++ b/src/main/java/com/smartinvoice/invoice/scheduler/ReminderScheduler.java
@@ -22,9 +22,8 @@ public class ReminderScheduler {
 
     @Scheduled(cron = "0 * * * * *") // every minute
     public void runReminderTask() {
-        List<Invoice> unpaidInvoices = invoiceRepository.findAll()
+        List<Invoice> unpaidInvoices = invoiceRepository.findAllUnpaidWithProducts()
                 .stream()
-                .filter(invoice -> !Boolean.TRUE.equals(invoice.getIsPaid()))
                 .filter(this::shouldSendReminder)
                 .toList();
 


### PR DESCRIPTION
When `runReminderTask()` was called, the Hibernate session was already closed, which prevented `invoice.getProducts()` from being fetched. To resolve this, I created a custom query to eagerly fetch products, `findAllUnpaidWithProducts()` with a custom query in `InvoiceRepository`. And changed the `unpaidInvoices`  List.

This will ensure invoices and their products are loaded within the same session, avoiding the `LazyInitializationException`.