### PR TITLE
feat: prevent duplicate reminder emails by tracking sent dates

### DIFF
--- a/src/main/java/com/smartinvoice/invoice/entity/Invoice.java
+++ b/src/main/java/com/smartinvoice/invoice/entity/Invoice.java
@@ -7,7 +7,9 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "invoices")
@@ -45,4 +47,10 @@ public class Invoice {
             inverseJoinColumns = @JoinColumn(name = "product_id")
     )
     private List<Product> products;
+
+    @ElementCollection
+    @CollectionTable(name = "invoice_reminders", joinColumns = @JoinColumn(name = "invoice_id"))
+    @Column(name = "reminder_date")
+    private Set<LocalDate> reminderSentDates = new HashSet<>();
+
 }

--- a/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
+++ b/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
@@ -7,6 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface InvoiceRepository extends JpaRepository<Invoice, Long> {
-    @Query("SELECT i FROM Invoice i LEFT JOIN FETCH i.products WHERE i.isPaid = false")
-    List<Invoice> findAllUnpaidWithProducts();
+    @Query("""
+                SELECT DISTINCT i FROM Invoice i
+                LEFT JOIN FETCH i.products
+                LEFT JOIN FETCH i.reminderSentDates
+                WHERE i.isPaid = false
+            """)
+    List<Invoice> findAllUnpaidWithProductsAndReminders();
+
 }


### PR DESCRIPTION
This PR introduces a robust system to prevent duplicate reminder emails from being sent to clients and resolves the `LazyInitializationException` related to accessing the `reminderSentDates` collection in a scheduled context.

### Key Changes:
#### Reminder tracking:

- Added Set<LocalDate> reminderSentDates to the Invoice entity.

- Updated the scheduler to skip dates that were already used for sending reminders.

- Saved the current reminder date after a successful email send.

#### Hibernate Lazy Loading Fix:

- Defined a custom repository method `findAllUnpaidWithProductsAndReminders()` using JOIN FETCH to eagerly load both products and `reminderSentDates`.

Ensured that all necessary data is available when accessed in the scheduled task, which runs outside of a transactional context.