### PR TITLE
Prepare for audit logging feature

### DIFF
--- a/src/main/java/com/smartinvoice/audit/entity/AuditLog.java
+++ b/src/main/java/com/smartinvoice/audit/entity/AuditLog.java
@@ -1,0 +1,28 @@
+package com.smartinvoice.audit.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "audit_logs")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String action;
+
+    private String entity;
+
+    private String entityId;
+
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/smartinvoice/audit/repository/AuditLogRepository.java
+++ b/src/main/java/com/smartinvoice/audit/repository/AuditLogRepository.java
@@ -1,0 +1,7 @@
+package com.smartinvoice.audit.repository;
+
+import com.smartinvoice.audit.entity.AuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+}

--- a/src/main/java/com/smartinvoice/audit/service/AuditLogService.java
+++ b/src/main/java/com/smartinvoice/audit/service/AuditLogService.java
@@ -1,0 +1,25 @@
+package com.smartinvoice.audit.service;
+
+import com.smartinvoice.audit.entity.AuditLog;
+import com.smartinvoice.audit.repository.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AuditLogService {
+
+    private final AuditLogRepository auditLogRepository;
+
+    public void log(String action, String entity, String entityId) {
+        AuditLog log = AuditLog.builder()
+                .action(action)
+                .entity(entity)
+                .entityId(entityId)
+                .timestamp(LocalDateTime.now())
+                .build();
+        auditLogRepository.save(log);
+    }
+}


### PR DESCRIPTION
This PR introduces a simple audit logging mechanism to track actions within the application, focusing first on invoice-related operations. User identity isn't logged, as the client cancelled the authentication feature.

- Created `AuditLog` entity to store action type, timestamp, and description.
- Added `AuditLogRepository` for persistence.
- Created `AuditLogService` with a method to log actions from any part of the system.