### PR TITLE
feat: add CSV export for all clients

### DIFF
--- a/src/main/java/com/smartinvoice/client/controller/ClientController.java
+++ b/src/main/java/com/smartinvoice/client/controller/ClientController.java
@@ -7,6 +7,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
 
 import java.util.List;
 
@@ -47,5 +50,12 @@ public class ClientController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteClient(@PathVariable Long id) {
         clientService.deleteClient(id);
+    }
+
+    @GetMapping(value = "/export", produces = "text/csv")
+    public void exportClientsToCsv(HttpServletResponse response) throws IOException {
+        response.setContentType("text/csv");
+        response.setHeader("Content-Disposition", "attachment; filename=clients.csv");
+        clientService.writeClientsToCsv(response);
     }
 }

--- a/src/main/java/com/smartinvoice/client/service/ClientService.java
+++ b/src/main/java/com/smartinvoice/client/service/ClientService.java
@@ -7,9 +7,12 @@ import com.smartinvoice.client.entity.Client;
 import com.smartinvoice.client.repository.ClientRepository;
 import com.smartinvoice.exception.ResourceNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -83,6 +86,27 @@ public class ClientService {
         repository.delete(existingClient);
 
         auditLogService.log("DELETE", "Client", String.valueOf(existingClient.getId()));
+    }
+
+    public void writeClientsToCsv(HttpServletResponse response) throws IOException {
+        List<ClientResponseDto> clients = getAllClients();
+
+        try (PrintWriter writer = response.getWriter()) {
+            writer.println("id,name,email,companyName,address,city,country,postcode");
+
+            for (ClientResponseDto client : clients) {
+                writer.printf("%d,%s,%s,%s,%s,%s,%s,%s%n",
+                        client.id(),
+                        client.name(),
+                        client.email(),
+                        client.companyName(),
+                        client.address(),
+                        client.city(),
+                        client.country(),
+                        client.postcode()
+                );
+            }
+        }
     }
 
     private ClientResponseDto mapToDto(Client client) {


### PR DESCRIPTION
This PR introduces functionality to export client data to a CSV file.

A new `writeClientsToCsv` method in `ClientService` handles the data formatting and writing.
A new `/export` endpoint in `ClientController` triggers the CSV download.