### PR TITLE
Add CSV export functionality for invoices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
 			<artifactId>openpdf</artifactId>
 			<version>1.3.30</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.10.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
+++ b/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
@@ -3,6 +3,7 @@ package com.smartinvoice.invoice.controller;
 import com.smartinvoice.invoice.dto.InvoiceRequestDto;
 import com.smartinvoice.invoice.dto.InvoiceResponseDto;
 import com.smartinvoice.invoice.service.InvoiceService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -56,4 +58,11 @@ public class InvoiceController {
         invoiceService.emailInvoiceToClient(id);
     }
 
+    @GetMapping("/export")
+    public void exportInvoices(HttpServletResponse response) throws IOException {
+        response.setContentType("text/csv");
+        response.setHeader("Content-Disposition", "attachment; filename=invoices.csv");
+
+        invoiceService.exportInvoicesToCsv(response.getWriter());
+    }
 }

--- a/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
+++ b/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
@@ -10,10 +10,13 @@ import com.smartinvoice.invoice.entity.Invoice;
 import com.smartinvoice.invoice.pdf.PdfGeneratorService;
 import com.smartinvoice.invoice.repository.InvoiceRepository;
 import com.smartinvoice.product.repository.ProductRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -114,4 +117,23 @@ public class InvoiceService {
         auditLogService.log("EMAIL_SENT", "Invoice", String.valueOf(invoice.getId()));
     }
 
+    public void exportInvoicesToCsv(Writer writer) throws IOException {
+        List<Invoice> invoices = invoiceRepository.findAll();
+
+        try (CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(
+                "ID", "Invoice Number", "Issue Date", "Due Date", "Client Name", "Total Amount", "Is Paid"))) {
+
+            for (Invoice invoice : invoices) {
+                csvPrinter.printRecord(
+                        invoice.getId(),
+                        invoice.getInvoiceNumber(),
+                        invoice.getIssueDate(),
+                        invoice.getDueDate(),
+                        invoice.getClient().getName(),
+                        invoice.getTotalAmount(),
+                        invoice.getIsPaid()
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces the ability to export all invoice data to a CSV file, providing users with an easy way to download and analyze their financial records.

#### Key Changes:

- `InvoiceService.exportInvoicesToCsv(Writer writer)`: A new method that leverages the Apache Commons CSV library to generate the CSV output. It fetches all invoices, defines a clear header row (ID, Invoice Number, Issue Date, Due Date, Client Name, Total Amount, Is Paid), and writes each invoice record to the provided Writer.
- `InvoiceController.exportInvoices(HttpServletResponse response)`: A new GET endpoint at `/export` that triggers the invoice CSV download. It sets the appropriate content type and header for a downloadable file named invoices.csv and then passes the response writer to the InvoiceService for data population.
- Dependency: Added `org.apache.commons:commons-csv` to handle robust CSV generation.

This enhancement significantly improves data accessibility for invoice management and reporting.