### PR TITLE
refactor: centralize export endpoints in dedicated ExportController

### DIFF
--- a/src/main/java/com/smartinvoice/client/controller/ClientController.java
+++ b/src/main/java/com/smartinvoice/client/controller/ClientController.java
@@ -1,5 +1,6 @@
 package com.smartinvoice.client.controller;
 
+import com.smartinvoice.export.dto.ClientFilterRequest;
 import com.smartinvoice.client.dto.ClientRequestDto;
 import com.smartinvoice.client.dto.ClientResponseDto;
 import com.smartinvoice.client.service.ClientService;
@@ -50,12 +51,5 @@ public class ClientController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteClient(@PathVariable Long id) {
         clientService.deleteClient(id);
-    }
-
-    @GetMapping(value = "/export", produces = "text/csv")
-    public void exportClientsToCsv(HttpServletResponse response) throws IOException {
-        response.setContentType("text/csv");
-        response.setHeader("Content-Disposition", "attachment; filename=clients.csv");
-        clientService.writeClientsToCsv(response);
     }
 }

--- a/src/main/java/com/smartinvoice/client/repository/ClientRepository.java
+++ b/src/main/java/com/smartinvoice/client/repository/ClientRepository.java
@@ -2,6 +2,7 @@ package com.smartinvoice.client.repository;
 
 import com.smartinvoice.client.entity.Client;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface ClientRepository extends JpaRepository<Client, Long> {
+public interface ClientRepository extends JpaRepository<Client, Long>, JpaSpecificationExecutor<Client> {
 }

--- a/src/main/java/com/smartinvoice/export/controller/ExportController.java
+++ b/src/main/java/com/smartinvoice/export/controller/ExportController.java
@@ -1,0 +1,64 @@
+package com.smartinvoice.export.controller;
+
+import com.smartinvoice.export.dto.ClientFilterRequest;
+import com.smartinvoice.export.dto.InvoiceFilterRequest;
+import com.smartinvoice.client.service.ClientService;
+import com.smartinvoice.invoice.service.InvoiceService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/export")
+@RequiredArgsConstructor
+public class ExportController {
+
+    private final ClientService clientService;
+    private final InvoiceService invoiceService;
+
+    @GetMapping("/clients/csv")
+    public void exportClientsToCsv(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String companyName,
+            @RequestParam(required = false) String city,
+            @RequestParam(required = false) String country,
+            HttpServletResponse response) throws IOException {
+
+        // Set response headers
+        response.setContentType("text/csv");
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=\"clients_export.csv\"");
+
+        // Build filters and export
+        ClientFilterRequest filters = new ClientFilterRequest(name, companyName, city, country);
+        clientService.writeClientsToCsv(response, filters);
+    }
+
+    @GetMapping("/invoices/csv")
+    public void exportInvoicesToCsv(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate issueDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dueDate,
+            @RequestParam(required = false) Long clientId,
+            @RequestParam(required = false) Boolean isPaid,
+            HttpServletResponse response) throws IOException {
+
+        // Validate date range
+        if (issueDate != null && dueDate != null && issueDate.isAfter(dueDate)) {
+            throw new IllegalArgumentException("Start date must be before end date");
+        }
+
+        // Set response headers
+        response.setContentType("text/csv");
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=\"invoices_export.csv\"");
+
+        // Build filters and export
+        InvoiceFilterRequest filters = new InvoiceFilterRequest(issueDate, dueDate, clientId, isPaid);
+        invoiceService.exportInvoicesToCsv(response, filters);
+    }
+}

--- a/src/main/java/com/smartinvoice/export/dto/ClientFilterRequest.java
+++ b/src/main/java/com/smartinvoice/export/dto/ClientFilterRequest.java
@@ -1,0 +1,8 @@
+package com.smartinvoice.export.dto;
+
+public record ClientFilterRequest(
+        String name,
+        String companyName,
+        String city,
+        String country
+) {}

--- a/src/main/java/com/smartinvoice/export/dto/InvoiceFilterRequest.java
+++ b/src/main/java/com/smartinvoice/export/dto/InvoiceFilterRequest.java
@@ -1,0 +1,10 @@
+package com.smartinvoice.export.dto;
+
+import java.time.LocalDate;
+
+public record InvoiceFilterRequest(
+        LocalDate issueDate,
+        LocalDate dueDate,
+        Long clientId,
+        Boolean isPaid
+) {}

--- a/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
+++ b/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
@@ -58,11 +58,4 @@ public class InvoiceController {
         invoiceService.emailInvoiceToClient(id);
     }
 
-    @GetMapping("/export")
-    public void exportInvoices(HttpServletResponse response) throws IOException {
-        response.setContentType("text/csv");
-        response.setHeader("Content-Disposition", "attachment; filename=invoices.csv");
-
-        invoiceService.exportInvoicesToCsv(response.getWriter());
-    }
 }

--- a/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
+++ b/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
@@ -2,11 +2,12 @@ package com.smartinvoice.invoice.repository;
 
 import com.smartinvoice.invoice.entity.Invoice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface InvoiceRepository extends JpaRepository<Invoice, Long> {
+public interface InvoiceRepository extends JpaRepository<Invoice, Long>, JpaSpecificationExecutor<Invoice> {
     @Query("""
                 SELECT DISTINCT i FROM Invoice i
                 LEFT JOIN FETCH i.products


### PR DESCRIPTION
#### Changes:

- Moved CSV exports from entity controllers to new `ExportController`
- Added filter DTOs (`ClientFilterRequest`, `InvoiceFilterRequest`)
- Modified `ClientService` and `InvoiceService` to:
       - Add filter support using JPA Specifications
       - Move CSV generation logic into service layer
- Improve error handling for exports
- Maintained same functionality with cleaner structure

#### New endpoints

```GET /api/export/clients/csv{?filters}```
```GET /api/export/invoices/csv{?filters}```

#### Recommended Enhancements:

- Add async processing for large exports
- Add rate limiting