### PR TITLE
 Add overdue invoice tracking and reminders

### DIFF
--- a/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
+++ b/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
@@ -1,7 +1,10 @@
 package com.smartinvoice.invoice.controller;
 
+import com.smartinvoice.exception.ResourceNotFoundException;
 import com.smartinvoice.invoice.dto.InvoiceRequestDto;
 import com.smartinvoice.invoice.dto.InvoiceResponseDto;
+import com.smartinvoice.invoice.entity.Invoice;
+import com.smartinvoice.invoice.repository.InvoiceRepository;
 import com.smartinvoice.invoice.service.InvoiceService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -12,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -20,6 +24,7 @@ import java.util.List;
 public class InvoiceController {
 
     private final InvoiceService invoiceService;
+    private final InvoiceRepository invoiceRepository;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -58,4 +63,9 @@ public class InvoiceController {
         invoiceService.emailInvoiceToClient(id);
     }
 
+    @PatchMapping("/{id}/mark-paid")
+    public ResponseEntity<Void> markAsPaid(@PathVariable Long id) {
+        invoiceService.markAsPaid(id);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/smartinvoice/invoice/dto/InvoiceResponseDto.java
+++ b/src/main/java/com/smartinvoice/invoice/dto/InvoiceResponseDto.java
@@ -1,5 +1,7 @@
 package com.smartinvoice.invoice.dto;
 
+import com.smartinvoice.invoice.entity.Invoice;
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -11,5 +13,7 @@ public record InvoiceResponseDto(
         double totalAmount,
         Long clientId,
         List<Long> productIds,
-        Boolean isPaid
+        Boolean isPaid,
+        Invoice.InvoiceStatus status
+
 ) {}

--- a/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
+++ b/src/main/java/com/smartinvoice/invoice/repository/InvoiceRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface InvoiceRepository extends JpaRepository<Invoice, Long>, JpaSpecificationExecutor<Invoice> {
@@ -16,4 +17,9 @@ public interface InvoiceRepository extends JpaRepository<Invoice, Long>, JpaSpec
             """)
     List<Invoice> findAllUnpaidWithProductsAndReminders();
 
+    List<Invoice> findByDueDateBeforeAndStatus(LocalDate date, Invoice.InvoiceStatus status);
+
+    List<Invoice> findByStatus(Invoice.InvoiceStatus status);
+
+    List<Invoice> findByOverdueSinceBefore(LocalDate date);
 }

--- a/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
+++ b/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -87,6 +88,15 @@ public class InvoiceService {
         auditLogService.log("DELETE", "Invoice", String.valueOf(invoice.getId()));
     }
 
+    public void markAsPaid(Long invoiceId) {
+        Invoice invoice = invoiceRepository.findById(invoiceId)
+                .orElseThrow(() -> new ResourceNotFoundException("Invoice not found"));
+
+        invoice.setStatus(Invoice.InvoiceStatus.PAID);
+        invoice.setPaidDate(LocalDate.now());
+        invoiceRepository.save(invoice);
+    }
+
     private InvoiceResponseDto mapToDto(Invoice invoice) {
         return new InvoiceResponseDto(
                 invoice.getId(),
@@ -96,7 +106,8 @@ public class InvoiceService {
                 invoice.getTotalAmount(),
                 invoice.getClient().getId(),
                 invoice.getProducts().stream().map(p -> p.getId()).collect(Collectors.toList()),
-                invoice.getIsPaid()
+                invoice.getIsPaid(),
+                invoice.getStatus()
         );
     }
 

--- a/src/main/java/com/smartinvoice/invoice/util/InvoiceStatusUpdater.java
+++ b/src/main/java/com/smartinvoice/invoice/util/InvoiceStatusUpdater.java
@@ -1,0 +1,29 @@
+package com.smartinvoice.invoice.util;
+
+import com.smartinvoice.invoice.entity.Invoice;
+import com.smartinvoice.invoice.repository.InvoiceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class InvoiceStatusUpdater {
+
+    private final InvoiceRepository invoiceRepository;
+
+    @Scheduled(cron = "0 * * * * *") // every day at 8:00 AM (cron = "0 0 8 * * *")
+    public void updateInvoiceStatuses() {
+        LocalDate today = LocalDate.now();
+
+        // Mark newly overdue invoices
+        invoiceRepository.findByDueDateBeforeAndStatus(today, Invoice.InvoiceStatus.PENDING)
+                .forEach(invoice -> {
+                    invoice.setStatus(Invoice.InvoiceStatus.OVERDUE);
+                    invoice.setOverdueSince(today);
+                    invoiceRepository.save(invoice);
+                });
+    }
+}


### PR DESCRIPTION
####Changes:

- Added `InvoiceStatus` enum (PENDING/PAID/OVERDUE)

Created scheduled jobs for:
- Daily status updates (`InvoiceStatusUpdater`)
- Overdue reminders (`ReminderScheduler`)
- Implemented /mark-paid endpoint
- Added reminder frequency rules (1,5,10 days overdue)

####New Features:

- Automatic overdue detection
- Configurable reminder schedule
- Payment status tracking

####Testing:

- Verified status transitions
- Confirmed reminder timing
- Tested mark-paid endpoint

####To do:
- Test behaviour of reminders if a client has 2 or more invoices with status (PENDING or OVERDUE).
- Test behaviour of reminders if a OVERDUE invoice is paid.
- Change cron for `@Scheduled` to the appropriate one
