### PR TITLE
feat(user): Add endpoint to return authenticated user data

### DIFF
--- a/src/main/java/com/smartinvoice/auth/controller/AuthController.java
+++ b/src/main/java/com/smartinvoice/auth/controller/AuthController.java
@@ -1,14 +1,19 @@
 package com.smartinvoice.auth.controller;
 
+import com.smartinvoice.auth.entity.User;
+import com.smartinvoice.auth.repository.UserRepository;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -16,6 +21,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentUser(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
+
+        String username = authentication.getName();
+        Optional<User> optionalUser = userRepository.findByUsername(username);
+
+        return optionalUser
+                .map(user -> ResponseEntity.ok().body(Map.of("username", user.getUsername())))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "User not found")));
+
+    }
 
     @PostMapping("/login")
     public String login(@RequestParam String username, @RequestParam String password, HttpSession session) {


### PR DESCRIPTION
This PR adds a new endpoint to fetch the currently authenticated user's information for use in the frontend authentication flow.

#### What's Implemented:

- `GET /api/user/me` endpoint added
- Returns the current user's username based on Spring Security's Authentication object
- Returns 401 if not authenticated, 404 if the user is not found in the database

Supports frontend AuthContext for persistent login across reloads