### PR TITLE
fix(auth): Changed return statements to JSON from String

### DIFF
--- a/src/main/java/com/smartinvoice/auth/controller/AuthController.java
+++ b/src/main/java/com/smartinvoice/auth/controller/AuthController.java
@@ -39,19 +39,20 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public String login(@RequestParam String username, @RequestParam String password, HttpSession session) {
+    public ResponseEntity<?> login(@RequestParam String username, @RequestParam String password, HttpSession session) {
         var authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(username, password)
         );
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
         session.setAttribute("username", username);
-        return "Login successful";
+        return ResponseEntity.ok(Map.of("message", "Login successful"));
     }
 
     @PostMapping("/logout")
-    public String logout(HttpSession session) {
+    public ResponseEntity<?> logout(HttpSession session) {
         session.invalidate();
-        return "Logged out";
+        return ResponseEntity.ok(Map.of("message", "Logged out"));
     }
+
 }


### PR DESCRIPTION
### Resolving "Network Error" on Frontend Despite 200 OK
An investigation pinpointed the cause of the "Network error" appearing on the frontend, even when the backend successfully returned a 200 OK status. This issue stemmed from a frontend bug related to how responses, particularly those with plain text or no content, were being handled.

To rectify this, a key backend modification was implemented:

`AuthController` login and logout methods on  now return `ResponseEntity<?>` instead of a String. This ensures a properly formatted JSON response is consistently sent, improving frontend compatibility and error handling.