### PR TITLE
Prevent frontend error on unauthenticated session check + enable secure login flow

### DIFF
--- a/smart-invoice-frontend/src/api/api.js
+++ b/smart-invoice-frontend/src/api/api.js
@@ -34,6 +34,10 @@ export const getCurrentUser = async () => {
       credentials: "include",
     });
 
+    const isJson = response.headers
+    .get("content-type")
+    ?.includes("application/json");
+
     if (response.status === 401) {
       return { ok: false, status: 401 };
     }
@@ -42,7 +46,7 @@ export const getCurrentUser = async () => {
 
     return {
       ok: true,
-      data: await response.json()
+      data: isJson ? await response.json() : null,
     };
   } catch (error) {
     console.error('API Error:', error);


### PR DESCRIPTION
#### Problem Summary
JSON Parse Error on Unauthenticated Load
When navigating to `/login` or refreshing the app, the frontend made a request to `/api/auth/me`. If the user was not logged in, the Spring Boot backend returned a default HTML error page. This caused a `SyntaxError: Unexpected token '<' `in the frontend, since `response.json()` was called on an HTML response.

#### CORS & JSESSIONID Session Issue
Despite a successful login via the `/api/auth/login` endpoint, authenticated requests like `/api/clients` failed with a 403 Forbidden. The issue was that the session cookie (JSESSIONID) wasn’t being included in cross-origin requests due to missing credentials configuration and CORS headers on the backend.

#### Fix Summary
Graceful handling of unauthenticated `/auth/me`:
Updated `getCurrentUser()` in api.js to:

Check `response.ok` before parsing JSON
Handle 403/401 responses without crashing the frontend
Return null when no session exists

#### CORS Configuration Update:

Set `Access-Control-Allow-Credentials: true` on the Spring Boot backend
Allowed origin explicitly: `http://localhost:5173`
Allowed all required headers and methods in the CORS config

#### Frontend credentials fix:

Configured all fetch requests (api.js) to use credentials: 'include' so that the browser sends the JSESSIONID cookie with every request