### PR TITLE
Fix: Ensure unauthenticated users are redirected to /login

### DIFF
--- a/smart-invoice-frontend/src/components/AppLayout.jsx
+++ b/smart-invoice-frontend/src/components/AppLayout.jsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from '../components/Navbar';
-import { useAuth } from '../contexts/AuthContext';
 
 const AppLayout = () => {
-  const { user } = useAuth();
-
-  if (!user) return null;
-
   return (
     <div className="min-h-screen bg-zinc-900 text-zinc-100">
       <Navbar />

--- a/smart-invoice-frontend/src/components/PrivateRoute.jsx
+++ b/smart-invoice-frontend/src/components/PrivateRoute.jsx
@@ -6,5 +6,9 @@ export default function PrivateRoute({ children }) {
 
   if (loading) return <div>Loading...</div>;
 
-  return user ? children : <Navigate to="/login" />;
-}
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};

--- a/smart-invoice-frontend/src/contexts/AuthContext.jsx
+++ b/smart-invoice-frontend/src/contexts/AuthContext.jsx
@@ -10,11 +10,16 @@ export const AuthProvider = ({ children }) => {
   const checkSession = async () => {
     try {
       const { ok, data } = await getCurrentUser();
-      if (ok && data) {
+      if (ok && data && data.username) {
         setUser(data.username);
+      } else {
+        setUser(null);
       }
+      console.log("Session check → ok:", ok, "data:", data);
+
     } catch (error) {
       console.error('Session check error:', error);
+      setUser(null);
     } finally {
       setLoading(false);
     }

--- a/smart-invoice-frontend/src/main.jsx
+++ b/smart-invoice-frontend/src/main.jsx
@@ -8,6 +8,7 @@ import Login from './pages/Login';
 import Clients from './pages/Clients';
 import Products from './pages/Products';
 import Invoices from './pages/Invoices';
+import PrivateRoute from './components/PrivateRoute';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 
 function AppWrapper() {
@@ -16,16 +17,45 @@ function AppWrapper() {
   if (loading) {
     return <div className="flex justify-center items-center h-screen">Loading...</div>;
   }
+  console.log("ROUTE DEBUG", { user, loading, location: window.location.pathname });
+
+  console.log('Auth loading:', loading, 'User:', user);
+
 
   return (
     <Routes>
       <Route path="/login" element={user ? <Navigate to="/clients" replace /> : <Login />} />
-      <Route element={<AppLayout />}>
-        <Route path="/clients" element={<Clients />} />
-        <Route path="/products" element={<Products />} />
-        <Route path="/invoices" element={<Invoices />} />
-        <Route path="/" element={<Navigate to="/clients" replace />} />
+      <Route path="/" element={<AppLayout />}>
+        <Route
+          path="/clients"
+          element={
+            <PrivateRoute>
+              <Clients />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/products"
+          element={
+            <PrivateRoute>
+              <Products />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/invoices"
+          element={
+            <PrivateRoute>
+              <Invoices />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          index
+          element={<Navigate to={user ? "/clients" : "/login"} replace />}
+        />
       </Route>
+
       <Route path="*" element={<Navigate to={user ? "/clients" : "/login"} replace />} />
     </Routes>
   );

--- a/src/main/java/com/smartinvoice/auth/config/SecurityConfig.java
+++ b/src/main/java/com/smartinvoice/auth/config/SecurityConfig.java
@@ -24,11 +24,12 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/login", "/api/auth/logout").permitAll()
+                        .requestMatchers("/api/auth/me").authenticated()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form
-                        .loginProcessingUrl("/api/auth/login")        // ← your JS hits this URL
-                        .successHandler((req, res, auth) -> {         // 200 & JSON on success
+                        .loginProcessingUrl("/api/auth/login")
+                        .successHandler((req, res, auth) -> {
                             res.setContentType("application/json");
                             res.getWriter().write("{\"username\":\"" + auth.getName() + "\"}");
                         })
@@ -36,7 +37,7 @@ public class SecurityConfig {
                                 res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Bad credentials"))
                         .permitAll()
                 )
-                .httpBasic(httpBasic -> httpBasic.disable());      // keep popup OFF
+                .httpBasic(httpBasic -> httpBasic.disable());
         return http.build();
     }
 

--- a/src/main/java/com/smartinvoice/auth/controller/AuthController.java
+++ b/src/main/java/com/smartinvoice/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.smartinvoice.auth.controller;
 
-import com.smartinvoice.auth.entity.User;
 import com.smartinvoice.auth.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -11,10 +10,10 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -42,7 +41,9 @@ public class AuthController {
         );
 
         SecurityContextHolder.getContext().setAuthentication(auth);
-        request.getSession(true);
+        HttpSession session = request.getSession(true);
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+                SecurityContextHolder.getContext());
 
         return ResponseEntity.ok(Map.of("username", auth.getName()));
     }


### PR DESCRIPTION
This PR fixes an issue where unauthenticated users were not redirected to the `/login` page when accessing the root path (`/`) or protected routes like `/clients`, `/products`, and `/invoices`.

---

### Problem

- Visiting `/` while unauthenticated showed a blank or non-functional screen.
- Direct access to protected routes was allowed even when not logged in.
- `AppLayout` blocked route rendering by returning `null` when `user === null`.
- `/api/auth/me` returned `{ ok: true, data: null }` instead of `401`, due to missing session binding.

---

### Fixes Applied

#### Frontend

- **Routing Fix:**
  - Added `path="/"` to the layout route so the `<Route index ...>` would work properly.
  - Changed index route logic to:
    ```jsx
    <Route index element={<Navigate to={user ? "/clients" : "/login"} replace />} />
    ```

- **Protected Routes:**
  - Added a new `PrivateRoute` component to guard authenticated paths:
    ```jsx
    if (!user) return <Navigate to="/login" replace />;
    ```

- **AppLayout Fix:**
  - Removed `if (!user) return null;` from `AppLayout`.
  - Ensured `<Outlet />` is always rendered to allow nested routing.

- **Session Check:**
  - Improved `AuthContext` to set `user = null` when session check fails or returns `null`.

- **Fetch Fix:**
  - All fetch calls (e.g., `/api/auth/me`) include `credentials: "include"` to send cookies:
    ```js
    credentials: "include"
    ```

#### Backend

- **Login Session Binding:**
  - In `AuthController`, explicitly stored the `SecurityContext` in the session:
    ```java
    session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, SecurityContextHolder.getContext());
    ```

- **Security Config:**
  - Updated `SecurityFilterChain` to protect `/api/auth/me`:
    ```java
    .requestMatchers("/api/auth/me").authenticated()
    ```