### PR TITLE
feat: include client name in invoice response DTO for frontend display

### DIFF
--- a/src/main/java/com/smartinvoice/invoice/dto/InvoiceResponseDto.java
+++ b/src/main/java/com/smartinvoice/invoice/dto/InvoiceResponseDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public record InvoiceResponseDto(
         Long id,
+        String clientName,
         String invoiceNumber,
         LocalDate issueDate,
         LocalDate dueDate,

--- a/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
+++ b/src/main/java/com/smartinvoice/invoice/service/InvoiceService.java
@@ -100,6 +100,7 @@ public class InvoiceService {
     private InvoiceResponseDto mapToDto(Invoice invoice) {
         return new InvoiceResponseDto(
                 invoice.getId(),
+                invoice.getClient().getName(),
                 invoice.getInvoiceNumber(),
                 invoice.getIssueDate(),
                 invoice.getDueDate(),


### PR DESCRIPTION
## Pull Request: Feat: Include Client Name in Invoice Response DTO for Frontend Display

---

### Description

This PR enhances the `InvoiceResponseDto` by including the client's name. This change is crucial for the frontend to display the client's name directly within the invoice list without requiring additional API calls for each invoice's client details.

This aligns with the frontend's new invoice UI that expects the `clientName` field.

### Changes Made

* **`InvoiceResponseDto` Modification:** Added a new field `String clientName` to the DTO record.
* **`mapToDto` Method Update:** Modified the `mapToDto` method in the `InvoiceService` (or equivalent mapping class) to extract the `client.getName()` and map it to the new `clientName` field in the `InvoiceResponseDto`.
