### PR TITLE
feat: add invoice search and filter by payment status

### DIFF
--- a/smart-invoice-frontend/src/pages/Invoices.jsx
+++ b/smart-invoice-frontend/src/pages/Invoices.jsx
@@ -5,11 +5,17 @@ export default function Invoices() {
   const [invoices, setInvoices] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedInvoice, setSelectedInvoice] = useState(null);
+  const [search, setSearch] = useState('');
+  const [isPaid, setIsPaid] = useState('');
 
   const fetchInvoices = async () => {
     setLoading(true);
     try {
-      const res = await fetch('http://localhost:8080/api/invoices', {
+      const params = new URLSearchParams();
+      if (search) params.append("search", search);
+      if (isPaid !== '') params.append("isPaid", isPaid);
+
+      const res = await fetch(`http://localhost:8080/api/invoices?${params.toString()}`, {
         credentials: 'include',
       });
       const data = await res.json();
@@ -23,7 +29,7 @@ export default function Invoices() {
 
   useEffect(() => {
     fetchInvoices();
-  }, []);
+  }, [search, isPaid]);
 
   const openInvoiceModal = (id) => {
     fetch(`http://localhost:8080/api/invoices/${id}`, {
@@ -66,6 +72,32 @@ export default function Invoices() {
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold mb-4">Invoices</h1>
+
+      <div className="mb-4 flex flex-col md:flex-row items-center gap-4">
+        <input
+          type="text"
+          placeholder="Search by invoice number..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="px-3 py-2 rounded border border-zinc-600 bg-zinc-800 text-white w-full md:w-1/2"
+        />
+        <select
+          value={isPaid}
+          onChange={(e) => setIsPaid(e.target.value)}
+          className="px-3 py-2 rounded border border-zinc-600 bg-zinc-800 text-white"
+        >
+          <option value="">All</option>
+          <option value="true">Paid</option>
+          <option value="false">Unpaid</option>
+        </select>
+        <button
+          onClick={fetchInvoices}
+          className="px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-700 text-white"
+        >
+          Apply Filters
+        </button>
+      </div>
+
       {invoices.length === 0 ? (
         <p>No invoices found.</p>
       ) : (
@@ -140,4 +172,5 @@ export default function Invoices() {
       />
     </div>
   );
+
 }

--- a/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
+++ b/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
@@ -1,12 +1,10 @@
 package com.smartinvoice.invoice.controller;
 
-import com.smartinvoice.exception.ResourceNotFoundException;
+import com.smartinvoice.invoice.dto.InvoiceSearchFilter;
 import com.smartinvoice.invoice.dto.InvoiceRequestDto;
 import com.smartinvoice.invoice.dto.InvoiceResponseDto;
-import com.smartinvoice.invoice.entity.Invoice;
 import com.smartinvoice.invoice.repository.InvoiceRepository;
 import com.smartinvoice.invoice.service.InvoiceService;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,8 +12,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -33,9 +29,12 @@ public class InvoiceController {
     }
 
     @GetMapping
-    public List<InvoiceResponseDto> getAllInvoices() {
-        return invoiceService.getAllInvoices();
+    public List<InvoiceResponseDto> getAllInvoices(
+            @ModelAttribute InvoiceSearchFilter filter
+    ) {
+        return invoiceService.getFilteredInvoices(filter);
     }
+
 
     @GetMapping("/{id}")
     public InvoiceResponseDto getInvoiceById(@PathVariable Long id) {

--- a/src/main/java/com/smartinvoice/invoice/dto/InvoiceSearchFilter.java
+++ b/src/main/java/com/smartinvoice/invoice/dto/InvoiceSearchFilter.java
@@ -1,0 +1,4 @@
+package com.smartinvoice.invoice.dto;
+
+public record InvoiceSearchFilter(String search, Boolean isPaid) {
+}


### PR DESCRIPTION
### Backend Changes

#### `InvoiceController.java`

- Updated `GET /api/invoices` endpoint to support optional query parameters:
  - `search` — filters invoices by partial match on invoice number (case-insensitive).
  - `isPaid` — filters by payment status.
- Constructed a new `InvoiceSearchFilter` DTO to encapsulate filter criteria and pass it to the service layer.

#### `InvoiceService.java`

- Added `getFilteredInvoices(InvoiceSearchFilter filter)` method.
- Built a dynamic `Specification<Invoice>` to query based on:
   - Invoice number (LIKE, case-insensitive)
   - Payment status (true/false)
- Reused the `mapToDto` method to return consistent `InvoiceResponseDto` results.

#### New File: `InvoiceSearchFilter.java`

- This DTO helps encapsulate search and filter logic in a clean and extendable way.

### Frontend Changes
#### `Invoice.jsx`
Added controlled inputs for:

- Invoice number search
- isPaid filter (All, Paid, Unpaid)
- Modified `fetchInvoices` to pass filter parameters as query params.
- Used `useEffect([search, isPaid])` to auto-fetch when filters change.
- Updated filter UI with Tailwind-styled input and select components.