### PR TITLE
Add keyword search and sorting to client filtering

### DIFF
--- a/src/main/java/com/smartinvoice/client/controller/ClientController.java
+++ b/src/main/java/com/smartinvoice/client/controller/ClientController.java
@@ -1,6 +1,6 @@
 package com.smartinvoice.client.controller;
 
-import com.smartinvoice.export.dto.ClientFilterRequest;
+import com.smartinvoice.client.dto.ClientFilterRequest;
 import com.smartinvoice.client.dto.ClientRequestDto;
 import com.smartinvoice.client.dto.ClientResponseDto;
 import com.smartinvoice.client.service.ClientService;
@@ -8,9 +8,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-
 
 import java.util.List;
 
@@ -30,8 +27,14 @@ public class ClientController {
 
     // Get a list of all clients
     @GetMapping
-    public List<ClientResponseDto> getAllClients() {
-        return clientService.getAllClients();
+    public List<ClientResponseDto> getClients(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String city,
+            @RequestParam(required = false) String country,
+            @RequestParam(required = false) String sortBy
+    ) {
+        ClientFilterRequest filters = new ClientFilterRequest(keyword, city, country, sortBy);
+        return clientService.getFilteredClients(filters);
     }
 
     // Get a single client by ID

--- a/src/main/java/com/smartinvoice/client/dto/ClientFilterRequest.java
+++ b/src/main/java/com/smartinvoice/client/dto/ClientFilterRequest.java
@@ -1,0 +1,8 @@
+package com.smartinvoice.client.dto;
+
+public record ClientFilterRequest(
+        String keyword,
+        String city,
+        String country,
+        String sortBy
+) {}

--- a/src/main/java/com/smartinvoice/export/controller/ExportController.java
+++ b/src/main/java/com/smartinvoice/export/controller/ExportController.java
@@ -1,6 +1,6 @@
 package com.smartinvoice.export.controller;
 
-import com.smartinvoice.export.dto.ClientFilterRequest;
+import com.smartinvoice.export.dto.ExportClientFilterRequest;
 import com.smartinvoice.export.dto.InvoiceFilterRequest;
 import com.smartinvoice.client.service.ClientService;
 import com.smartinvoice.invoice.service.InvoiceService;
@@ -35,7 +35,7 @@ public class ExportController {
                 "attachment; filename=\"clients_export.csv\"");
 
         // Build filters and export
-        ClientFilterRequest filters = new ClientFilterRequest(name, companyName, city, country);
+        ExportClientFilterRequest filters = new ExportClientFilterRequest(name, companyName, city, country);
         clientService.writeClientsToCsv(response, filters);
     }
 

--- a/src/main/java/com/smartinvoice/export/dto/ExportClientFilterRequest.java
+++ b/src/main/java/com/smartinvoice/export/dto/ExportClientFilterRequest.java
@@ -1,6 +1,6 @@
 package com.smartinvoice.export.dto;
 
-public record ClientFilterRequest(
+public record ExportClientFilterRequest(
         String name,
         String companyName,
         String city,


### PR DESCRIPTION
This PR extends the backend functionality for the Clients module to support advanced filtering and sorting.

### Changes

- Updated `ClientFilterRequest` (in `com.smartinvoice.client.dto`) to include:
  - `keyword`: searches across name, email, and companyName
  - `city`: filter by city (case insensitive)
  - `country`: filter by country (case insensitive)
  - `sortBy`: dynamic sorting by name, city, or country (asc/desc supported)

- Updated `ClientService`:
  - Refactored `getFilteredClients()` to use new filters
  - Added dynamic `Specification<Client>` using JPA Criteria API
  - Implemented flexible `Sort` generation logic

- Adjusted repository call:
  ```java
  repository.findAll(withFilters(filters), getSort(filters.sortBy()))
