### PR TITLE
fix(client): add explicit /filter endpoint to prevent path variable conflict

### DIFF
--- a/src/main/java/com/smartinvoice/client/controller/ClientController.java
+++ b/src/main/java/com/smartinvoice/client/controller/ClientController.java
@@ -37,6 +37,12 @@ public class ClientController {
         return clientService.getFilteredClients(filters);
     }
 
+    @GetMapping("/filter")
+    public List<ClientResponseDto> getFilteredClients(ClientFilterRequest filters) {
+        return clientService.getFilteredClients(filters);
+    }
+
+
     // Get a single client by ID
     @GetMapping("/{id}")
     public ClientResponseDto getClientById(@PathVariable Long id) {


### PR DESCRIPTION
## Fix: Prevent MethodArgumentTypeMismatch when accessing `/api/clients/filter`

### Problem
The application was throwing a `MethodArgumentTypeMismatchException` when accessing `/api/clients/filter` because Spring interpreted `filter` as a client ID path variable due to the generic `/{id}` mapping.

### Solution
Introduced a dedicated `@GetMapping("/filter")` method for filtering clients using `ClientFilterRequest`.

### Code:
```java
@GetMapping("/filter")
public List<ClientResponseDto> getFilteredClients(ClientFilterRequest filters) {
    return clientService.getFilteredClients(filters);
}
