### PR TITLE
feat(product): add keyword search and sorting support to product filtering

### DIFF
--- a/src/main/java/com/smartinvoice/product/controller/ProductController.java
+++ b/src/main/java/com/smartinvoice/product/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.smartinvoice.product.controller;
 
+import com.smartinvoice.product.dto.ProductFilterRequest;
 import com.smartinvoice.product.dto.ProductRequestDto;
 import com.smartinvoice.product.dto.ProductResponseDto;
 import com.smartinvoice.product.service.ProductService;
@@ -43,4 +44,12 @@ public class ProductController {
     public void delete(@PathVariable Long id) {
         service.delete(id);
     }
+
+    @GetMapping("/filter")
+    public List<ProductResponseDto> filterProducts(@RequestParam(required = false) String keyword,
+                                                   @RequestParam(required = false) String sortBy) {
+        ProductFilterRequest filters = new ProductFilterRequest(keyword, sortBy);
+        return service.getFilteredProducts(filters);
+    }
+
 }

--- a/src/main/java/com/smartinvoice/product/dto/ProductFilterRequest.java
+++ b/src/main/java/com/smartinvoice/product/dto/ProductFilterRequest.java
@@ -1,0 +1,6 @@
+package com.smartinvoice.product.dto;
+
+public record ProductFilterRequest(
+        String keyword,
+        String sortBy // name, -name, price, -price
+) {}

--- a/src/main/java/com/smartinvoice/product/repository/ProductRepository.java
+++ b/src/main/java/com/smartinvoice/product/repository/ProductRepository.java
@@ -2,6 +2,7 @@ package com.smartinvoice.product.repository;
 
 import com.smartinvoice.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpecificationExecutor<Product> {
 }

--- a/src/main/java/com/smartinvoice/product/service/ProductService.java
+++ b/src/main/java/com/smartinvoice/product/service/ProductService.java
@@ -1,12 +1,15 @@
 package com.smartinvoice.product.service;
 
 import com.smartinvoice.audit.service.AuditLogService;
+import com.smartinvoice.product.dto.ProductFilterRequest;
 import com.smartinvoice.product.dto.ProductRequestDto;
 import com.smartinvoice.product.dto.ProductResponseDto;
 import com.smartinvoice.product.entity.Product;
 import com.smartinvoice.product.repository.ProductRepository;
 import com.smartinvoice.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -70,6 +73,36 @@ public class ProductService {
 
         auditLogService.log("DELETE", "Product", String.valueOf(existing.getId()));
     }
+
+    public List<ProductResponseDto> getFilteredProducts(ProductFilterRequest filter) {
+        return repository.findAll(withFilters(filter), getSort(filter.sortBy()))
+                .stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    private Specification<Product> withFilters(ProductFilterRequest filter) {
+        return (root, query, cb) -> {
+            if (filter.keyword() != null && !filter.keyword().isBlank()) {
+                String kw = "%" + filter.keyword().toLowerCase() + "%";
+                return cb.like(cb.lower(root.get("name")), kw);
+            }
+            return cb.conjunction();
+        };
+    }
+
+    private Sort getSort(String sortBy) {
+        if (sortBy == null || sortBy.isBlank()) return Sort.unsorted();
+
+        return switch (sortBy) {
+            case "name" -> Sort.by(Sort.Direction.ASC, "name");
+            case "-name" -> Sort.by(Sort.Direction.DESC, "name");
+            case "price" -> Sort.by(Sort.Direction.ASC, "price");
+            case "-price" -> Sort.by(Sort.Direction.DESC, "price");
+            default -> Sort.unsorted();
+        };
+    }
+
 
     private ProductResponseDto mapToDto(Product product) {
         return new ProductResponseDto(


### PR DESCRIPTION
Feature: Product Filtering and Sorting (Backend)

This PR introduces backend support for filtering and sorting products via the API.

### Features Implemented

- **Keyword Search**: Products can be searched by name (case-insensitive)
- **Sorting Options**:
  - `name`: Ascending
  - `-name`: Descending
  - `price`: Ascending
  - `-price`: Descending

### Changes Summary

- Added new DTO: `ProductFilterRequest`
- Updated `ProductService` to support dynamic filtering and sorting via JPA Specifications and Sort
- Added new endpoint: `GET /api/products/filter`
- Updated `ProductRepository` to extend `JpaSpecificationExecutor`

