### PR TITLE
fix: change filter label to "Sort By" on Invoices page

### DIFF
--- a/smart-invoice-frontend/src/pages/Invoices.jsx
+++ b/smart-invoice-frontend/src/pages/Invoices.jsx
@@ -95,7 +95,7 @@ export default function Invoices() {
         </div>
 
         <div className="flex flex-col">
-          <label className="mb-1 text-sm font-medium text-white">Payment Status</label>
+          <label className="mb-1 text-sm font-medium text-white">Sort By</label>
           <select
             value={isPaid}
             onChange={e => setIsPaid(e.target.value)}


### PR DESCRIPTION
### What Changed
- Corrected the filter label above the status dropdown in **Invoices.jsx** from “Payment Status” back to “Sort By”.

### File Updated
- `src/pages/Invoices.jsx`