### PR TITLE
Fix/unused dependency invoice controller

### DIFF
--- a/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
+++ b/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
@@ -20,7 +20,6 @@ import java.util.List;
 public class InvoiceController {
 
     private final InvoiceService invoiceService;
-    private final InvoiceRepository invoiceRepository;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
+++ b/src/main/java/com/smartinvoice/invoice/controller/InvoiceController.java
@@ -3,7 +3,6 @@ package com.smartinvoice.invoice.controller;
 import com.smartinvoice.invoice.dto.InvoiceSearchFilter;
 import com.smartinvoice.invoice.dto.InvoiceRequestDto;
 import com.smartinvoice.invoice.dto.InvoiceResponseDto;
-import com.smartinvoice.invoice.repository.InvoiceRepository;
 import com.smartinvoice.invoice.service.InvoiceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
Summary:

Removed unused `InvoiceRepository` from the `InvoiceController` to avoid the need to mock an unused bean.