### PR TITLE
Add unit tests for PdfGeneratorService with happy, edge, and failure scenarios

### DIFF
--- a/src/test/java/com/smartinvoice/invoice/pdf/PdfGeneratorServiceTest.java
+++ b/src/test/java/com/smartinvoice/invoice/pdf/PdfGeneratorServiceTest.java
@@ -1,17 +1,18 @@
 package com.smartinvoice.invoice.pdf;
 
-import com.lowagie.text.DocumentException;
+import com.smartinvoice.company.CompanyProperties;
+import com.smartinvoice.company.CompanyProperties.BankDetails;
 import com.smartinvoice.client.entity.Client;
 import com.smartinvoice.invoice.entity.Invoice;
 import com.smartinvoice.product.entity.Product;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 class PdfGeneratorServiceTest {
 
@@ -19,52 +20,117 @@ class PdfGeneratorServiceTest {
 
     @BeforeEach
     void setUp() {
-        pdfGeneratorService = new PdfGeneratorService();
+        CompanyProperties companyProperties = new CompanyProperties();
+        companyProperties.setName("SmartInvoice Ltd");
+        companyProperties.setAddress("123 Test Street");
+        companyProperties.setCity("London");
+        companyProperties.setCountry("UK");
+        companyProperties.setPostCode("E1 6AN");
+        companyProperties.setPhone("0123456789");
+        companyProperties.setEmail("info@smartinvoice.com");
+
+        BankDetails bank = new BankDetails();
+        bank.setHolder("SmartInvoice Ltd");
+        bank.setAccount("12345678");
+        bank.setSortCode("12-34-56");
+        companyProperties.setBank(bank);
+
+        pdfGeneratorService = new PdfGeneratorService(companyProperties);
     }
 
     @Test
-    void shouldGeneratePdfFromInvoice() throws DocumentException {
-        // Arrange
+    @DisplayName("Should generate PDF for valid invoice")
+    void shouldGeneratePdfSuccessfully() {
         Client client = Client.builder()
-                .id(1L)
-                .name("Emma Graphic Studio")
-                .email("emma@studio.com")
-                .companyName("Emma Designs")
+                .name("Alice")
+                .address("1 Main St")
+                .city("London")
+                .country("UK")
+                .postcode("E1 1AA")
                 .build();
 
-        Product product1 = Product.builder()
-                .id(1L)
+        Product product = Product.builder()
+                .name("Logo Design")
+                .price(250.0)
+                .build();
+
+        Invoice invoice = Invoice.builder()
+                .client(client)
+                .invoiceNumber("INV-001")
+                .issueDate(LocalDate.now())
+                .dueDate(LocalDate.now().plusDays(7))
+                .products(List.of(product))
+                .totalAmount(250.0)
+                .isPaid(false)
+                .build();
+
+        byte[] result = pdfGeneratorService.generateInvoicePdf(invoice);
+
+        assertThat(result).isNotNull();
+        assertThat(result.length).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("Should throw exception when invoice is null")
+    void shouldThrowWhenInvoiceIsNull() {
+        assertThatThrownBy(() -> pdfGeneratorService.generateInvoicePdf(null))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Failed to generate PDF");
+    }
+
+    @Test
+    @DisplayName("Should handle missing client info without crashing")
+    void shouldHandleMissingClientFieldsGracefully() {
+        Client client = Client.builder()
+                .name(null)
+                .address(null)
+                .city(null)
+                .country(null)
+                .postcode(null)
+                .build();
+
+        Product product = Product.builder()
                 .name("Logo Design")
                 .price(150.0)
                 .build();
 
-        Product product2 = Product.builder()
-                .id(2L)
-                .name("Business Card Design")
-                .price(100.0)
+        Invoice invoice = Invoice.builder()
+                .client(client)
+                .invoiceNumber("INV-002")
+                .issueDate(LocalDate.now())
+                .dueDate(LocalDate.now().plusDays(7))
+                .products(List.of(product))
+                .totalAmount(150.0)
+                .isPaid(true)
+                .build();
+
+        byte[] pdf = pdfGeneratorService.generateInvoicePdf(invoice);
+
+        assertThat(pdf).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("Should throw if product list is empty")
+    void shouldFailWithEmptyProductList() {
+        Client client = Client.builder()
+                .name("Bob")
+                .address("123 Lane")
+                .city("London")
+                .country("UK")
+                .postcode("E2 2BB")
                 .build();
 
         Invoice invoice = Invoice.builder()
-                .id(1L)
-                .invoiceNumber("INV-1001")
+                .client(client)
+                .invoiceNumber("INV-003")
                 .issueDate(LocalDate.now())
                 .dueDate(LocalDate.now().plusDays(7))
-                .client(client)
-                .products(List.of(product1, product2))
-                .totalAmount(250.0)
+                .products(List.of())
+                .totalAmount(0.0)
+                .isPaid(false)
                 .build();
 
-        // Act
-        byte[] pdf = pdfGeneratorService.generateInvoicePdf(invoice);
-
-        // Assert
-        assertThat(pdf).isNotNull();
-        assertThat(pdf.length).isGreaterThan(0);
-
-        // Optionally verify it's a valid PDF header
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(pdf);
-        byte[] header = new byte[4];
-        inputStream.read(header, 0, 4);
-        assertThat(new String(header)).isEqualTo("%PDF");
+        byte[] result = pdfGeneratorService.generateInvoicePdf(invoice);
+        assertThat(result).isNotEmpty();
     }
 }


### PR DESCRIPTION
This PR adds a robust set of unit tests for the `PdfGeneratorService`, covering:

- Happy path: PDF generation for a complete and valid invoice
- Edge cases: Missing client fields and empty product list
- Failure scenario: Null invoice input throws an expected exception

All tests use `AssertJ` for expressive assertions. These tests help validate the reliability of the PDF generation logic and ensure graceful handling of imperfect data.