### PR TITLE
refactor: move business logic from ExportController to ExportService

### DIFF
--- a/src/main/java/com/smartinvoice/export/controller/ExportController.java
+++ b/src/main/java/com/smartinvoice/export/controller/ExportController.java
@@ -1,15 +1,18 @@
 package com.smartinvoice.export.controller;
 
 import com.smartinvoice.client.dto.ClientFilterRequest;
+import com.smartinvoice.client.service.ClientService;
 import com.smartinvoice.export.dto.ExportClientFilterRequest;
 import com.smartinvoice.export.dto.InvoiceFilterRequest;
-import com.smartinvoice.client.service.ClientService;
+import com.smartinvoice.export.service.ExportService;
 import com.smartinvoice.invoice.service.InvoiceService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpHeaders;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -21,6 +24,7 @@ public class ExportController {
 
     private final ClientService clientService;
     private final InvoiceService invoiceService;
+    private final ExportService exportService;
 
     @GetMapping("/clients/csv")
     public void exportClientsToCsv(
@@ -30,34 +34,9 @@ public class ExportController {
             @RequestParam(required = false) String country,
             HttpServletResponse response) throws IOException {
 
-        // Set headers
-        response.setContentType("text/csv");
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
-                "attachment; filename=\"clients_export.csv\"");
-
-        // Map ExportClientFilterRequest to ClientFilterRequest
         ExportClientFilterRequest exportFilters = new ExportClientFilterRequest(name, companyName, city, country);
-
-        // Keyword = combination of name + company name
-        String keyword = buildKeywordFrom(exportFilters.name(), exportFilters.companyName());
-
-        // Create a compatible ClientFilterRequest with keyword
-        ClientFilterRequest adapted = new ClientFilterRequest(
-                keyword,
-                exportFilters.city(),
-                exportFilters.country(),
-                null
-        );
-
+        ClientFilterRequest adapted = exportService.mapToClientFilter(exportFilters);
         clientService.writeClientsToCsv(response, adapted);
-    }
-
-    private String buildKeywordFrom(String name, String companyName) {
-        if (name == null && companyName == null) return null;
-        StringBuilder sb = new StringBuilder();
-        if (name != null) sb.append(name).append(" ");
-        if (companyName != null) sb.append(companyName);
-        return sb.toString().trim();
     }
 
     @GetMapping("/invoices/csv")
@@ -68,17 +47,7 @@ public class ExportController {
             @RequestParam(required = false) Boolean isPaid,
             HttpServletResponse response) throws IOException {
 
-        // Validate date range
-        if (issueDate != null && dueDate != null && issueDate.isAfter(dueDate)) {
-            throw new IllegalArgumentException("Start date must be before end date");
-        }
-
-        // Set response headers
-        response.setContentType("text/csv");
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
-                "attachment; filename=\"invoices_export.csv\"");
-
-        // Build filters and export
+        exportService.validateInvoiceDates(issueDate, dueDate);
         InvoiceFilterRequest filters = new InvoiceFilterRequest(issueDate, dueDate, clientId, isPaid);
         invoiceService.exportInvoicesToCsv(response, filters);
     }

--- a/src/main/java/com/smartinvoice/export/service/ExportService.java
+++ b/src/main/java/com/smartinvoice/export/service/ExportService.java
@@ -1,0 +1,29 @@
+package com.smartinvoice.export.service;
+
+import com.smartinvoice.client.dto.ClientFilterRequest;
+import com.smartinvoice.export.dto.ExportClientFilterRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+public class ExportService {
+    public ClientFilterRequest mapToClientFilter(ExportClientFilterRequest req) {
+        String keyword = buildKeyword(req.name(), req.companyName());
+        return new ClientFilterRequest(keyword, req.city(), req.country(), null);
+    }
+
+    public void validateInvoiceDates(LocalDate issueDate, LocalDate dueDate) {
+        if (issueDate != null && dueDate != null && issueDate.isAfter(dueDate)) {
+            throw new IllegalArgumentException("Start date must be before end date");
+        }
+    }
+
+    private String buildKeyword(String name, String companyName) {
+        if (name == null && companyName == null) return null;
+        StringBuilder sb = new StringBuilder();
+        if (name != null) sb.append(name).append(" ");
+        if (companyName != null) sb.append(companyName);
+        return sb.toString().trim();
+    }
+}


### PR DESCRIPTION
This PR improves code structure by refactoring `ExportController` to follow the single responsibility principle. Previously, the controller handled logic related to:

- Keyword construction for client filtering
- Mapping DTOs from export to domain filter objects
- Validating invoice export date ranges

#### These concerns have been extracted into a new `ExportService` class to:

- Promote better separation of concerns
- Simplify controller code for readability and maintainability
- Facilitate unit testing of transformation and validation logic independently of the web layer

#### Changes introduced:

- New `ExportService` with:
  - `mapToClientFilter()`
  - `validateInvoiceDates()`
  - `buildKeyword()`

- Updated `ExportController` to use `ExportService`
- Injected `ExportService` via constructor

This is a structural refactor only. There are no changes to API endpoints or behavior.