### PR TITLE
Add ExportController integration tests with global exception handling

### DIFF
--- a/src/main/java/com/smartinvoice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/smartinvoice/exception/GlobalExceptionHandler.java
@@ -12,4 +12,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleResourceNotFound(ResourceNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
 }

--- a/src/test/java/com/smartinvoice/export/controller/ExportControllerTests.java
+++ b/src/test/java/com/smartinvoice/export/controller/ExportControllerTests.java
@@ -1,0 +1,90 @@
+package com.smartinvoice.export.controller;
+
+import com.smartinvoice.client.dto.ClientFilterRequest;
+import com.smartinvoice.client.service.ClientService;
+import com.smartinvoice.exception.GlobalExceptionHandler;
+import com.smartinvoice.export.dto.ExportClientFilterRequest;
+import com.smartinvoice.export.dto.InvoiceFilterRequest;
+import com.smartinvoice.export.service.ExportService;
+import com.smartinvoice.invoice.service.InvoiceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ExportControllerTest {
+
+    private MockMvc mockMvc;
+    private ClientService clientService;
+    private InvoiceService invoiceService;
+    private ExportService exportService;
+
+    @BeforeEach
+    void setup() {
+        clientService = mock(ClientService.class);
+        invoiceService = mock(InvoiceService.class);
+        exportService = mock(ExportService.class);
+
+        ExportController controller = new ExportController(clientService, invoiceService, exportService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Should export clients with filters - happy path")
+    void exportClientsToCsv_happy() throws Exception {
+        doNothing().when(clientService).writeClientsToCsv(any(), any(ClientFilterRequest.class));
+        when(exportService.mapToClientFilter(any(ExportClientFilterRequest.class)))
+                .thenReturn(new ClientFilterRequest("John", "London", "UK", null));
+
+        mockMvc.perform(get("/api/export/clients/csv")
+                        .param("name", "John")
+                        .param("city", "London")
+                        .param("country", "UK"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should export invoices with valid dates - happy path")
+    void exportInvoicesToCsv_happy() throws Exception {
+        doNothing().when(invoiceService).exportInvoicesToCsv(any(), any(InvoiceFilterRequest.class));
+        doNothing().when(exportService).validateInvoiceDates(any(), any());
+
+        mockMvc.perform(get("/api/export/invoices/csv")
+                        .param("issueDate", "2024-01-01")
+                        .param("dueDate", "2024-02-01"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when issue date is after due date - unhappy path")
+    void exportInvoicesToCsv_invalidDateRange() throws Exception {
+        doThrow(new IllegalArgumentException("Start date must be before end date"))
+                .when(exportService).validateInvoiceDates(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 1, 1));
+
+        mockMvc.perform(get("/api/export/invoices/csv")
+                        .param("issueDate", "2024-02-01")
+                        .param("dueDate", "2024-01-01"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should export invoices with no filters - edge case")
+    void exportInvoicesToCsv_noFilters() throws Exception {
+        doNothing().when(invoiceService).exportInvoicesToCsv(any(), any(InvoiceFilterRequest.class));
+        doNothing().when(exportService).validateInvoiceDates(any(), any());
+
+        mockMvc.perform(get("/api/export/invoices/csv"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
This PR introduces comprehensive tests for the `ExportController` covering happy, unhappy, and edge case scenarios. It also ensures that the global exception handling is correctly wired for `IllegalArgumentException`, such as when an invoice export is requested with an invalid date range.

### What’s Included
Added integration-style tests for:

- Exporting clients with valid filters
- Exporting invoices with valid, invalid, or no filters
- Tested for bad requests when issue date > due date

Integrated `GlobalExceptionHandler` with `MockMvc` using `.setControllerAdvice(...)`

### Technical Notes

- Used `MockMvcBuilders.standaloneSetup()` with `.setControllerAdvice(new GlobalExceptionHandler())` to properly test error mapping.
- Verified that `IllegalArgumentException` results in HTTP 400 (Bad Request).