### PR TITLE
test: add unit test for AuditLogService to verify audit log creation and save behavior

### DIFF
--- a/src/test/java/com/smartinvoice/audit/AuditLogServiceTest.java
+++ b/src/test/java/com/smartinvoice/audit/AuditLogServiceTest.java
@@ -1,0 +1,41 @@
+package com.smartinvoice.audit;
+
+import com.smartinvoice.audit.repository.AuditLogRepository;
+import com.smartinvoice.audit.service.AuditLogService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
+
+class AuditLogServiceTest {
+
+    private AuditLogRepository repository;
+    private AuditLogService service;
+
+    @BeforeEach
+    void setup() {
+        repository = mock(AuditLogRepository.class);
+        service = new AuditLogService(repository);
+    }
+
+    @Test
+    @DisplayName("Should create and save an audit log entry")
+    void log_shouldSaveAuditEntry() {
+        // Given
+        String action = "CREATE";
+        String entity = "Client";
+        String entityId = "123";
+
+        // When
+        service.log(action, entity, entityId);
+
+        // Then
+        verify(repository, times(1)).save(argThat(log ->
+                log.getAction().equals(action) &&
+                        log.getEntity().equals(entity) &&
+                        log.getEntityId().equals(entityId) &&
+                        log.getTimestamp() != null
+        ));
+    }
+}


### PR DESCRIPTION
# Add Unit Test for `AuditLogService`

## Summary

This pull request introduces a focused unit test for the `AuditLogService` to validate that audit logs are correctly constructed and saved using the `AuditLogRepository`.

## What was added

- `AuditLogServiceTest` class
- Verifies that the `log()` method creates an `AuditLog` entity with expected fields: `action`, `entity`, `entityId`, and a non-null `timestamp`
- Uses Mockito to isolate and assert repository interaction

## Why it matters

This test improves unit test coverage for the `audit.service` layer and ensures that the auditing mechanism logs actions reliably. This lays the groundwork for future audit-related features, such as viewing audit history or exporting logs.

## Notes

- This test uses mocked dependencies; we plan to extend this with Testcontainers integration in a future iteration to verify persistence at the database level.

## Coverage Impact

Increases test coverage for the `audit` module, previously untested.

---
🔧 Ready for review.
