### PR TITLE
Add unit tests for UserService covering user registration and lookup

### DIFF
--- a/src/test/java/com/smartinvoice/auth/service/UserServiceTest.java
+++ b/src/test/java/com/smartinvoice/auth/service/UserServiceTest.java
@@ -1,0 +1,65 @@
+package com.smartinvoice.auth.service;
+
+import com.smartinvoice.auth.dto.UserRequestDto;
+import com.smartinvoice.auth.entity.User;
+import com.smartinvoice.auth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        userService = new UserService(userRepository, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("Should register user with encoded password")
+    void registerUser_shouldSucceed() {
+        UserRequestDto dto = new UserRequestDto("admin", "secret");
+        when(passwordEncoder.encode("secret")).thenReturn("encodedSecret");
+        User savedUser = User.builder().id(1L).username("admin").password("encodedSecret").build();
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        User result = userService.registerUser(dto);
+
+        assertThat(result.getUsername()).isEqualTo("admin");
+        assertThat(result.getPassword()).isEqualTo("encodedSecret");
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("Should return user by username")
+    void findByUsername_shouldReturnUser() {
+        User user = User.builder().id(1L).username("admin").password("pass").build();
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
+
+        User result = userService.findByUsername("admin");
+
+        assertThat(result.getUsername()).isEqualTo("admin");
+    }
+
+    @Test
+    @DisplayName("Should throw exception when user not found")
+    void findByUsername_shouldThrowWhenNotFound() {
+        when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.findByUsername("unknown"))
+                .isInstanceOf(UsernameNotFoundException.class)
+                .hasMessage("User not found");
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces unit tests for the `UserService` class:

- `registerUser` - ensures user is created with an encoded password and saved to the repository.
- `findByUsername` - verifies retrieval of user by username.
- `findByUsername` unhappy path - confirms `UsernameNotFoundException` is thrown when user not found.

Although `registerUser` is not used in the project (user is created manually in the DB), testing it ensures coverage and guards against future misuse or changes.

### Coverage Impact

Improves backend test coverage and reinforces authentication service reliability."